### PR TITLE
Updated graph_endpoint to slack_endpoint because of Slack single action URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 7/4/2016: [#28](https://github.com/dblock/slack-market/issues/28): Rename Slack action endpoint - [@ddruker](https://github.com/ddruker).
 * 7/2/2016: [#26](https://github.com/dblock/slack-market/issues/26): Supports lowercase ticker symbols, eg. `$aapl` - [@dblock](https://github.com/dblock).
 * 7/2/2016: Require a 1.99$ subscription after 7 days - [@dblock](https://github.com/dblock).
 * 7/2/2016: [#1](https://github.com/dblock/slack-market/issues/1): Display other types of graphs  - [@ddruker](https://github.com/ddruker).

--- a/slack-market/api/endpoints.rb
+++ b/slack-market/api/endpoints.rb
@@ -1,5 +1,5 @@
 require 'slack-market/api/endpoints/teams_endpoint'
 require 'slack-market/api/endpoints/subscriptions_endpoint'
 require 'slack-market/api/endpoints/status_endpoint'
-require 'slack-market/api/endpoints/graph_endpoint'
+require 'slack-market/api/endpoints/slack_endpoint'
 require 'slack-market/api/endpoints/root_endpoint'

--- a/slack-market/api/endpoints/root_endpoint.rb
+++ b/slack-market/api/endpoints/root_endpoint.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       mount Api::Endpoints::StatusEndpoint
-      mount Api::Endpoints::GraphEndpoint
+      mount Api::Endpoints::SlackEndpoint
       mount Api::Endpoints::TeamsEndpoint
       mount Api::Endpoints::SubscriptionsEndpoint
 

--- a/slack-market/api/endpoints/slack_endpoint.rb
+++ b/slack-market/api/endpoints/slack_endpoint.rb
@@ -1,17 +1,16 @@
-require 'pp'
 module Api
   module Endpoints
-    class GraphEndpoint < Grape::API
+    class SlackEndpoint < Grape::API
       format :json
 
-      namespace :graph do
-        desc 'Select graph.'
+      namespace :slack do
+        desc 'Respond to interactive slack buttons and actions.'
 
         params do
           requires :payload, type: String
         end
 
-        post do
+        post '/action' do
           payload = JSON.parse(params[:payload])
           button_name = payload['actions'][0]['name']
           button_value = payload['actions'][0]['value']

--- a/spec/api/documentation_spec.rb
+++ b/spec/api/documentation_spec.rb
@@ -9,7 +9,7 @@ describe Api do
       JSON.parse(last_response.body)
     end
     it 'documents root level apis' do
-      expect(subject['paths'].keys).to eq ['/api/status', '/api/graph', '/api/teams/{id}', '/api/teams', '/api/subscriptions']
+      expect(subject['paths'].keys).to eq ['/api/status', '/api/slack/action', '/api/teams/{id}', '/api/teams', '/api/subscriptions']
     end
   end
 

--- a/spec/api/endpoints/slack_endpoint_spec.rb
+++ b/spec/api/endpoints/slack_endpoint_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe Api::Endpoints::GraphEndpoint do
+describe Api::Endpoints::SlackEndpoint do
   include Api::Test::EndpointTest
 
   context 'graph' do
     it 'parses a good payload', vcr: { cassette_name: 'msft' } do
-      post '/api/graph', payload: {
+      post '/api/slack/action', payload: {
         'actions': [{ 'name' => '1m', 'value' => 'MSFT- 1m' }],
         'channel': { 'id' => '424242424', 'name' => 'directmessage' },
         'token': ENV['SLACK_VERIFICATION_TOKEN'],
@@ -16,7 +16,7 @@ describe Api::Endpoints::GraphEndpoint do
       expect(last_response.status).to eq 201
     end
     it 'returns an error with a non-matching verification token', vcr: { cassette_name: 'msft' } do
-      post '/api/graph', payload: {
+      post '/api/slack/action', payload: {
         'actions': [{ 'name' => '1m', 'value' => 'MSFT- 1m' }],
         'channel': { 'id' => '424242424', 'name' => 'directmessage' },
         'token': 'invalid-token',


### PR DESCRIPTION
Hey @dblock,

I updated the endpoint to be ``/api/slack/action``.  Please note that you must updated your request url to reflect the new endpoint. 

Thanks,

David