### PR TITLE
Support for Asian stock tickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 7/31/2016: [#36](https://github.com/dblock/slack-market/pull/36): Support numeric and alphanumeric stock tickers, eg. `Z74.SI` or `0941.HK` - [@pauljz](https://github.com/pauljz).
 * 7/25/2016: Notify subscribing teams - [@dblock](https://github.com/dblock).
 * 7/4/2016: [#28](https://github.com/dblock/slack-market/issues/28): Rename Slack action endpoint - [@ddruker](https://github.com/ddruker).
 * 7/2/2016: [#26](https://github.com/dblock/slack-market/issues/26): Supports lowercase ticker symbols, eg. `$aapl` - [@dblock](https://github.com/dblock).

--- a/slack-market/commands/quote.rb
+++ b/slack-market/commands/quote.rb
@@ -2,8 +2,8 @@ module SlackMarket
   module Commands
     class Quote < SlackRubyBot::Commands::Base
       scan(/
-        [\b\$]?[[[:upper:]]]{1,}[\.\-\=][[[:upper:]]]+\b|
-        \$[[[:alpha:]]]{1,}[\.\-\=][[[:alpha:]]]+|
+        [\b\$]?[A-Z0-9]{1,}[\.\-\=][[[:upper:]]]+\b|
+        \$[[[:alnum:]]]{1,}[\.\-\=][[[:alpha:]]]+|
         [\b\$]?[[[:upper:]]]{2,}\b|
         \$[[[:alpha:]]]{1,}|
         \b[[[:upper:]]]{1,}\$

--- a/spec/fixtures/slack/0941_hk.yml
+++ b/spec/fixtures/slack/0941_hk.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://download.finance.yahoo.com/d/quotes.csv?f=nsl1c1p2&s=0941.HK
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 31 Jul 2016 21:15:49 GMT
+      P3p:
+      - policyref="https://policies.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM
+        DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND
+        PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/octet-stream
+      Age:
+      - '0'
+      Via:
+      - http/1.1 media-router-api4.prod.media.gq1.yahoo.com (ApacheTrafficServer [cMsSf
+        ]), http/1.1 r12.ycpi.sjb.yahoo.net (ApacheTrafficServer [cMsSf ])
+      Server:
+      - ATS
+      Connection:
+      - keep-alive
+      Y-Trace:
+      - BAEAQAAAAACZ6Mz53P8eWwAAAAAAAAAA7MI9MyrPriIAAAAAAAAAAAAFOPT83sMGAAU49PzfLnjitnSXAAAAAA--
+    body:
+      encoding: UTF-8
+      string: '"CHINA MOBILE","0941.HK",95.65,-1.90,"-1.95%"
+
+'
+    http_version: 
+  recorded_at: Sun, 31 Jul 2016 21:15:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/slack/z74_si.yml
+++ b/spec/fixtures/slack/z74_si.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://download.finance.yahoo.com/d/quotes.csv?f=nsl1c1p2&s=Z74.SI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 31 Jul 2016 21:19:58 GMT
+      P3p:
+      - policyref="https://policies.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM
+        DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND
+        PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Length:
+      - '39'
+      Content-Type:
+      - application/octet-stream
+      Age:
+      - '0'
+      Via:
+      - http/1.1 media-router-api29.prod.media.gq1.yahoo.com (ApacheTrafficServer
+        [cMsSf ]), http/1.1 r11.ycpi.sjb.yahoo.net (ApacheTrafficServer [cMsSf ])
+      Server:
+      - ATS
+      Connection:
+      - keep-alive
+      Y-Trace:
+      - BAEAQAAAAABm0glhUDo_6wAAAAAAAAAAiu9bhYCbXWMAAAAAAAAAAAAFOPULu1kbAAU49Qu7wvE4y5F8AAAAAA--
+    body:
+      encoding: UTF-8
+      string: '"SingTel","Z74.SI",4.18,-0.11,"-2.56%"
+
+'
+    http_version: 
+  recorded_at: Sun, 31 Jul 2016 21:19:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/slack-market/commands/quote_spec.rb
+++ b/spec/slack-market/commands/quote_spec.rb
@@ -146,6 +146,91 @@ describe SlackMarket::Commands::Quote do
         message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$rog.vx?'))
         message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's $rog.VX?"))
       end
+      it 'returns a quote for 0941.HK', vcr: { cassette_name: '0941.hk', allow_playback_repeats: true } do
+        expect(client.web_client).to receive(:chat_postMessage).with(
+          channel: 'channel',
+          as_user: true,
+          attachments: [
+            {
+              fallback: 'CHINA MOBILE (0941.HK): $95.65',
+              title_link: 'http://finance.yahoo.com/q?s=0941.HK',
+              title: 'CHINA MOBILE (0941.HK)',
+              text: '$95.65 (-1.95%)',
+              color: '#FF0000',
+              callback_id: 'CHINA MOBILE',
+              actions: [
+                {
+                  name: '1d',
+                  text: '1d',
+                  type: 'button',
+                  value: '0941.HK- 1d'
+                },
+                {
+                  name: '1m',
+                  text: '1m',
+                  type: 'button',
+                  value: '0941.HK- 1m'
+                },
+                {
+                  name: '1y',
+                  text: '1y',
+                  type: 'button',
+                  value: '0941.HK- 1y'
+                }
+              ],
+              image_url: 'http://chart.finance.yahoo.com/z?s=0941.HK&z=l'
+            }
+          ]
+        ).exactly(5).times
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '0941.HK'))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's 0941.HK?"))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$0941.HK?'))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's $0941.HK?"))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$0941.hk?'))
+      end
+      it 'returns a quote for Z74.SI', vcr: { cassette_name: 'z74.si', allow_playback_repeats: true } do
+        expect(client.web_client).to receive(:chat_postMessage).with(
+          channel: 'channel',
+          as_user: true,
+          attachments: [
+            {
+              fallback: 'SingTel (Z74.SI): $4.18',
+              title_link: 'http://finance.yahoo.com/q?s=Z74.SI',
+              title: 'SingTel (Z74.SI)',
+              text: '$4.18 (-2.56%)',
+              color: '#FF0000',
+              callback_id: 'SingTel',
+              actions: [
+                {
+                  name: '1d',
+                  text: '1d',
+                  type: 'button',
+                  value: 'Z74.SI- 1d'
+                },
+                {
+                  name: '1m',
+                  text: '1m',
+                  type: 'button',
+                  value: 'Z74.SI- 1m'
+                },
+                {
+                  name: '1y',
+                  text: '1y',
+                  type: 'button',
+                  value: 'Z74.SI- 1y'
+                }
+              ],
+              image_url: 'http://chart.finance.yahoo.com/z?s=Z74.SI&z=l'
+            }
+          ]
+        ).exactly(6).times
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: 'Z74.SI'))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's Z74.SI?"))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$Z74.SI?'))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's $Z74.SI?"))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$z74.si?'))
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's $z74.SI?"))
+      end
       it 'returns a quote for MSFT and YHOO', vcr: { cassette_name: 'msft_yahoo_invalid' } do
         expect(client.web_client).to receive(:chat_postMessage).with(
           channel: 'channel',


### PR DESCRIPTION
Many Asian markets use numeric or alphanumeric stock tickers. A couple examples:

* [SingTel - Z74.SI](https://finance.yahoo.com/quote/Z74.SI)
* [China Mobile - 0941.HK](https://finance.yahoo.com/quote/0941.HK)

This should mostly avoid false-positives because we're only checking for things that are suffixed with an alphabetical market identifier.