### PR TITLE
Support for stocks that Yahoo Finance doesn't return a name for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 8/1/2016: [#37](https://github.com/dblock/slack-market/pull/37): Support stocks that Yahoo Finance fails to return a name for, e.g. `300024.SZ` - [@pauljz](https://github.com/pauljz).
 * 7/31/2016: [#36](https://github.com/dblock/slack-market/pull/36): Support numeric and alphanumeric stock tickers, eg. `Z74.SI` or `0941.HK` - [@pauljz](https://github.com/pauljz).
 * 7/25/2016: Notify subscribing teams - [@dblock](https://github.com/dblock).
 * 7/4/2016: [#28](https://github.com/dblock/slack-market/issues/28): Rename Slack action endpoint - [@ddruker](https://github.com/ddruker).

--- a/slack-market/models/market.rb
+++ b/slack-market/models/market.rb
@@ -12,7 +12,8 @@ class Market
     # return stock quotes
     def quotes(stocks, fields = [:name, :symbol, :last_trade_price, :change, :change_in_percent])
       YahooFinance::Client.new.quotes(stocks, fields).select do |quote|
-        quote.name != 'N/A'
+        quote.name = quote.name != 'N/A' ? quote.name : quote.symbol
+        quote.last_trade_price != 'N/A'
       end
     end
 

--- a/spec/fixtures/slack/300024_sz.yml
+++ b/spec/fixtures/slack/300024_sz.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://download.finance.yahoo.com/d/quotes.csv?f=nsl1c1p2&s=300024.SZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 01:40:57 GMT
+      P3p:
+      - policyref="https://policies.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM
+        DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND
+        PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/octet-stream
+      Age:
+      - '0'
+      Via:
+      - http/1.1 media-router-api8.prod.media.gq1.yahoo.com (ApacheTrafficServer [cMsSf
+        ]), http/1.1 r32.ycpi.sjb.yahoo.net (ApacheTrafficServer [cMsSf ])
+      Server:
+      - ATS
+      Connection:
+      - keep-alive
+      Y-Trace:
+      - BAEAQAAAAAAujIDk00gCpQAAAAAAAAAA4W35_PgtyO8AAAAAAAAAAAAFOTUKl9NEAAU5NQqYOoIgPik2AAAAAA--
+    body:
+      encoding: UTF-8
+      string: 'N/A,"300024.SZ",23.76,-0.04,"-0.17%"
+
+'
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 01:40:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -23,12 +23,25 @@ describe Market do
   describe '#quotes' do
     it 'filters out N/A responses' do
       allow_any_instance_of(YahooFinance::Client).to receive(:quotes).and_return([
-        Hashie::Mash.new(name: 'N/A'),
-        Hashie::Mash.new(name: 'MSFT')
+        Hashie::Mash.new(name: 'N/A', last_trade_price: 'N/A'),
+        Hashie::Mash.new(name: 'MSFT', last_trade_price: '56.58')
       ])
       quotes = Market.quotes(%w(FOO MSFT))
       expect(quotes.size).to eq 1
       expect(quotes[0].name).to eq 'MSFT'
+    end
+    it 'uses the symbol for the name if the name is N/A' do
+      allow_any_instance_of(YahooFinance::Client).to receive(:quotes).and_return([
+        Hashie::Mash.new(
+          name: 'N/A',
+          symbol: '300024.SZ',
+          last_trade_price: '23.71',
+          change: '+0.10',
+          change_in_percent: '+0.42%'
+        )
+      ])
+      quotes = Market.quotes(%w(300024.SZ))
+      expect(quotes[0].name).to eq '300024.SZ'
     end
   end
 end

--- a/spec/slack-market/commands/quote_spec.rb
+++ b/spec/slack-market/commands/quote_spec.rb
@@ -231,6 +231,44 @@ describe SlackMarket::Commands::Quote do
         message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$z74.si?'))
         message_command.call(client, Hashie::Mash.new(channel: 'channel', text: "How's $z74.SI?"))
       end
+      it 'returns a quote for 300024.SZ (no name)', vcr: { cassette_name: '300024.sz', allow_playback_repeats: true } do
+        expect(client.web_client).to receive(:chat_postMessage).with(
+          channel: 'channel',
+          as_user: true,
+          attachments: [
+            {
+              fallback: '300024.SZ (300024.SZ): $23.76',
+              title_link: 'http://finance.yahoo.com/q?s=300024.SZ',
+              title: '300024.SZ (300024.SZ)',
+              text: '$23.76 (-0.17%)',
+              color: '#FF0000',
+              callback_id: '300024.SZ',
+              actions: [
+                {
+                  name: '1d',
+                  text: '1d',
+                  type: 'button',
+                  value: '300024.SZ- 1d'
+                },
+                {
+                  name: '1m',
+                  text: '1m',
+                  type: 'button',
+                  value: '300024.SZ- 1m'
+                },
+                {
+                  name: '1y',
+                  text: '1y',
+                  type: 'button',
+                  value: '300024.SZ- 1y'
+                }
+              ],
+              image_url: 'http://chart.finance.yahoo.com/z?s=300024.SZ&z=l'
+            }
+          ]
+        ).exactly(1).times
+        message_command.call(client, Hashie::Mash.new(channel: 'channel', text: '$300024.SZ?'))
+      end
       it 'returns a quote for MSFT and YHOO', vcr: { cassette_name: 'msft_yahoo_invalid' } do
         expect(client.web_client).to receive(:chat_postMessage).with(
           channel: 'channel',


### PR DESCRIPTION
This is a weird one. I've found some stocks that don't return a name, but seem fine otherwise.

```sh
$ curl "http://download.finance.yahoo.com/d/quotes.csv?f=nsl1c1p2&s=300024.SZ"
N/A,"300024.SZ",23.75,+0.14,"+0.59%"
```
![300024.SZ](http://chart.finance.yahoo.com/z?s=300024.SZ&z=l)

As a quick fix we can still display these by using the symbol in place of the name. We still filter out things that are N/As using the last share price.
